### PR TITLE
Added Coinbase Wallet Integration

### DIFF
--- a/src/hooks/useConnection.tsx
+++ b/src/hooks/useConnection.tsx
@@ -102,6 +102,7 @@ export const initOnboard = (addressChangeCallback, walletChangeCallback, network
     walletSelect: {
       description: 'Please select a wallet to connect to the blockchain',
       wallets: [
+        { walletName: 'walletLink', preferred: true, rpcUrl: networkToProvider[networkId] },
         { walletName: 'metamask', preferred: true },
         {
           walletName: 'walletConnect',


### PR DESCRIPTION
I have integrated coinbase wallet into this project for users who are accustomed to tapping into DeFi using Coinbase wallet.
Also, I noticed that we are using ```bn-onboard``` to integrate various wallets. ```bn-onboard``` is now old and deprecated.
I'm working on another PR to upgrade the wallet integration to the latest version by blocknative i.e ```@web3-onboard/core```.